### PR TITLE
Endpoint key password Support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,3 +68,5 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Chris Pawling <https://github.com/chris468>
 	Matthias Fleschütz <https://github.com/blindzero>
 	Harri Rautila <https://github.com/hrautila>
+	Tatsuhiko Yasumatsu
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -68,3 +68,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Chris Pawling <https://github.com/chris468>
 	Matthias Fleschütz <https://github.com/blindzero>
 	Harri Rautila <https://github.com/hrautila>
+	Adam Stadler <https://github.com/tzfx>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+04/21/2021
+- on OAuth 2.0 RS token scope/claim 401 error, add environment variable for usage with mod_headers,
+  instead of adding a header ourselves; see #572; usage, e.g;
+    Header always append WWW-Authenticate %{OIDC_OAUTH_BEARER_SCOPE_ERROR}e "expr=(%{REQUEST_STATUS} == 401) && (-n reqenv('OIDC_OAUTH_BEARER_SCOPE_ERROR'))"
+- bump to 2.4.8-dev
+
 04/13/2021
 - add OIDCRedisCacheConnectTimeout and OIDCRedisCacheTimeout options to configure Redis timeouts
 - bump to 2.4.7.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 04/30/2021
-- fix potential crash when Content-Type is not set in POST requests; thanks JPCERT/CC
+- fix potential crash when Content-Type is not set in POST requests; thanks Tatsuhiko Yasumatsu of JPCERT/CC
 - release 2.4.8
 
 04/21/2021
@@ -118,6 +118,13 @@
 09/03/2020
 - add SameSite attribute on cookie clearance / logout; thanks @v0gler
 - bump to 2.4.4.1
+
+09/01/2020
+- forward port Tufin patches
+- always set session cookie same site policy to Lax
+- disable cookie domain check
+- unset host headers for metadata URL retrieval
+- bump to 2.4.4-tufin
 
 09/01/2020
 - avoid GCC 9 compiler warnings

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+04/30/2021
+- add OIDCClientTokenEndpointKeyPassword option to allow the use of an encrypted private key
+
 04/13/2021
 - add OIDCRedisCacheConnectTimeout and OIDCRedisCacheTimeout options to configure Redis timeouts
 - bump to 2.4.7.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+04/30/2021
+- fix potential crash when Content-Type is not set in POST requests; thanks JPCERT/CC
+- release 2.4.8
+
 04/21/2021
 - on OAuth 2.0 RS token scope/claim 401 error, add environment variable for usage with mod_headers,
   instead of adding a header ourselves; see #572; usage, e.g;

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ of claims provided in the `id_token`/ `userinfo` claims.
 - [OpenID Connect Session Management 1.0](http://openid.net/specs/openid-connect-session-1_0.html) *(implementers draft; see the [Wiki](https://github.com/zmartzone/mod_auth_openidc/wiki/OpenID-Connect-Session-Management) for information on how to configure it)*
 - [OpenID Connect Front-Channel Logout 1.0](http://openid.net/specs/openid-connect-frontchannel-1_0.html) *(implementers draft)*
 - [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html) *(implementers draft)*
-- [OpenID Connect Token Bound Authentication](https://openid.net/specs/openid-connect-token-bound-authentication-1_0.html) *(draft spec; when combined with [mod_token_binding](https://github.com/zmartzone/mod_token_binding))*
-- [OAuth 2.0 Token Binding for Authorization Codes for Web Server Clients](https://tools.ietf.org/html/draft-ietf-oauth-token-binding-07#section-5.2) *(draft spec)*
 
 For an exhaustive description of all configuration options, see the file `auth_openidc.conf`
 in this directory. This file can also serve as an include file for `httpd.conf`.
@@ -48,13 +46,13 @@ Support
 -------
 
 #### Community Support
-For generic questions, see the Wiki pages with Frequently Asked Questions at:  
+For documentation, see the Wiki pages (including Frequently Asked Questions) at:  
   [https://github.com/zmartzone/mod_auth_openidc/wiki](https://github.com/zmartzone/mod_auth_openidc/wiki)  
-There is a Google Group/mailing list at:  
-  [mod_auth_openidc@googlegroups.com](mailto:mod_auth_openidc@googlegroups.com)  
-The corresponding forum/archive is at:  
+For generic questions there is a Github Discussions forum at:  
+  [https://github.com/zmartzone/mod_auth_openidc/discussions](https://github.com/zmartzone/mod_auth_openidc/discussions)
+There is a (now deprecated) Google Group/mailing list archive at:  
   [https://groups.google.com/forum/#!forum/mod_auth_openidc](https://groups.google.com/forum/#!forum/mod_auth_openidc)  
-Any questions/issues should go to the mailing list.
+Any questions/issues should go to the Discussions forum.
 
 #### Commercial Services
 For commercial Support contracts, Professional Services, Training and use-case specific support you can contact:  

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -230,6 +230,11 @@
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: token_endpoint_tls_client_key
 #OIDCClientTokenEndpointKey <filename>
 
+# Password for the PEM-formatted private key that belongs to the client certificate used to authenticate the
+# Client in calls to the token endpoint of the OAuth 2.0 Authorization server.
+# NB: this can be overridden on a per-OP basis in the .conf file using the key: token_endpoint_tls_client_key_pwd
+#OIDCClientTokenEndpointKeyPasswd <filename>
+
 # The client name that the client registers in dynamic registration with the OP.
 # When not defined, no client name will be sent with the registration request.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: client_name

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -232,8 +232,11 @@
 
 # Password for the PEM-formatted private key that belongs to the client certificate used to authenticate the
 # Client in calls to the token endpoint of the OAuth 2.0 Authorization server.
+# If the value begins with exec: the resulting command will be executed and the
+# first line returned to standard output by the program will be used as the password.
+# The command may be absolute or relative to the web server root.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: token_endpoint_tls_client_key_pwd
-#OIDCClientTokenEndpointKeyPassword <passphrase>
+#OIDCClientTokenEndpointKeyPassword [ <passphrase> | "exec:/path/to/otherProgram arg1" ]
 
 # The client name that the client registers in dynamic registration with the OP.
 # When not defined, no client name will be sent with the registration request.

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -233,7 +233,7 @@
 # Password for the PEM-formatted private key that belongs to the client certificate used to authenticate the
 # Client in calls to the token endpoint of the OAuth 2.0 Authorization server.
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: token_endpoint_tls_client_key_pwd
-#OIDCClientTokenEndpointKeyPasswd <filename>
+#OIDCClientTokenEndpointKeyPassword <passphrase>
 
 # The client name that the client registers in dynamic registration with the OP.
 # When not defined, no client name will be sent with the registration request.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mod_auth_openidc],[2.4.7.2],[hans.zandbelt@zmartzone.eu])
+AC_INIT([mod_auth_openidc],[2.4.8-dev],[hans.zandbelt@zmartzone.eu])
 
 AC_SUBST(NAMEVER, AC_PACKAGE_TARNAME()-AC_PACKAGE_VERSION())
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mod_auth_openidc],[2.4.8-dev],[hans.zandbelt@zmartzone.eu])
+AC_INIT([mod_auth_openidc],[2.4.8],[hans.zandbelt@zmartzone.eu])
 
 AC_SUBST(NAMEVER, AC_PACKAGE_TARNAME()-AC_PACKAGE_VERSION())
 

--- a/src/config.c
+++ b/src/config.c
@@ -2967,7 +2967,7 @@ const command_rec oidc_config_cmds[] = {
 				RSRC_CONF,
 				"TLS client certificate private key used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCClientTokenEndpointKeyPassword,
-				oidc_set_string_slot,
+				oidc_set_passphrase_slot,
 				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd,
 				RSRC_CONF,
 				"TLS client certificate private key password used for calls to OpenID Connect OP token endpoint."),

--- a/src/config.c
+++ b/src/config.c
@@ -2968,7 +2968,7 @@ const command_rec oidc_config_cmds[] = {
 				"TLS client certificate private key used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCClientTokenEndpointKeyPassword,
 				oidc_set_passphrase_slot,
-				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd,
+				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd),
 				RSRC_CONF,
 				"TLS client certificate private key password used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCRedirectURI,

--- a/src/config.c
+++ b/src/config.c
@@ -210,7 +210,7 @@
 #define OIDCClientSecret                       "OIDCClientSecret"
 #define OIDCClientTokenEndpointCert            "OIDCClientTokenEndpointCert"
 #define OIDCClientTokenEndpointKey             "OIDCClientTokenEndpointKey"
-#define OIDCClientTokenEndpointKeyPassword     "ODICClientTokenEndpointPassword"
+#define OIDCClientTokenEndpointKeyPassword     "OIDCClientTokenEndpointKeyPassword"
 #define OIDCDefaultLoggedOutURL                "OIDCDefaultLoggedOutURL"
 #define OIDCCookieHTTPOnly                     "OIDCCookieHTTPOnly"
 #define OIDCCookieSameSite                     "OIDCCookieSameSite"
@@ -2968,7 +2968,7 @@ const command_rec oidc_config_cmds[] = {
 				"TLS client certificate private key used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCClientTokenEndpointKeyPassword,
 				oidc_set_passphrase_slot,
-				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd,
+				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd),
 				RSRC_CONF,
 				"TLS client certificate private key password used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCRedirectURI,

--- a/src/config.c
+++ b/src/config.c
@@ -210,6 +210,7 @@
 #define OIDCClientSecret                       "OIDCClientSecret"
 #define OIDCClientTokenEndpointCert            "OIDCClientTokenEndpointCert"
 #define OIDCClientTokenEndpointKey             "OIDCClientTokenEndpointKey"
+#define OIDCClientTokenEndpointKeyPassword     "ODICClientTokenEndpointPassword"
 #define OIDCDefaultLoggedOutURL                "OIDCDefaultLoggedOutURL"
 #define OIDCCookieHTTPOnly                     "OIDCCookieHTTPOnly"
 #define OIDCCookieSameSite                     "OIDCCookieSameSite"
@@ -1243,6 +1244,7 @@ void oidc_cfg_provider_init(oidc_provider_t *provider) {
 	provider->client_secret = NULL;
 	provider->token_endpoint_tls_client_cert = NULL;
 	provider->token_endpoint_tls_client_key = NULL;
+	provider->token_endpoint_tls_client_key_pwd = NULL;
 	provider->registration_endpoint_url = NULL;
 	provider->registration_endpoint_json = NULL;
 	provider->check_session_iframe = NULL;
@@ -1469,6 +1471,10 @@ void* oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			add->provider.token_endpoint_tls_client_key != NULL ?
 					add->provider.token_endpoint_tls_client_key :
 					base->provider.token_endpoint_tls_client_key;
+	c->provider.token_endpoint_tls_client_key_pwd =
+		add->provider.token_endpoint_tls_client_key_pwd != NULL ?
+				add->provider.token_endpoint_tls_client_key_pwd :
+				base->provider.token_endpoint_tls_client_key_pwd;
 	c->provider.token_endpoint_tls_client_cert =
 			add->provider.token_endpoint_tls_client_cert != NULL ?
 					add->provider.token_endpoint_tls_client_cert :
@@ -2960,7 +2966,11 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key),
 				RSRC_CONF,
 				"TLS client certificate private key used for calls to OpenID Connect OP token endpoint."),
-
+		AP_INIT_TAKE1(OIDCClientTokenEndpointKeyPassword,
+				oidc_set_string_slot,
+				(void*)APR_OFFSETOF(oidc_cfg, provider.token_endpoint_tls_client_key_pwd,
+				RSRC_CONF,
+				"TLS client certificate private key password used for calls to OpenID Connect OP token endpoint."),
 		AP_INIT_TAKE1(OIDCRedirectURI,
 				oidc_set_relative_or_absolute_url_slot,
 				(void *)APR_OFFSETOF(oidc_cfg, redirect_uri),

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -119,6 +119,7 @@ extern module AP_MODULE_DECLARE_DATA auth_openidc_module;
 #define OIDC_METADATA_USERINFO_REFRESH_INTERVAL                    "userinfo_refresh_interval"
 #define OIDC_METADATA_TOKEN_ENDPOINT_TLS_CLIENT_CERT               "token_endpoint_tls_client_cert"
 #define OIDC_METADATA_TOKEN_ENDPOINT_TLS_CLIENT_KEY                "token_endpoint_tls_client_key"
+#define OIDC_METADATA_TOKEN_ENDPOINT_TLS_CLIENT_KEY_PWD            "token_endpoint_tls_client_key_pwd"
 #define OIDC_METADATA_REQUEST_OBJECT                               "request_object"
 #define OIDC_METADATA_USERINFO_TOKEN_METHOD                        "userinfo_token_method"
 #define OIDC_METADATA_TOKEN_BINDING_POLICY                         "token_binding_policy"
@@ -1325,6 +1326,10 @@ apr_byte_t oidc_metadata_conf_parse(request_rec *r, oidc_cfg *cfg,
 			OIDC_METADATA_TOKEN_ENDPOINT_TLS_CLIENT_KEY,
 			&provider->token_endpoint_tls_client_key,
 			cfg->provider.token_endpoint_tls_client_key);
+	oidc_json_object_get_string(r->pool, j_conf,
+			OIDC_METADATA_TOKEN_ENDPOINT_TLS_CLIENT_KEY_PWD,
+			&provider->token_endpoint_tls_client_key_pwd,
+			cfg->provider.token_endpoint_tls_client_key_pwd);
 
 	oidc_json_object_get_string(r->pool, j_conf, OIDC_METADATA_REQUEST_OBJECT,
 			&provider->request_object, cfg->provider.request_object);

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -594,7 +594,7 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 			NULL, provider->registration_token, provider->ssl_validate_server, response,
 			cfg->http_timeout_short, cfg->outgoing_proxy,
 			oidc_dir_cfg_pass_cookies(r),
-			NULL, NULL) == FALSE) {
+			NULL, NULL, NULL) == FALSE) {
 		json_decref(data);
 		return FALSE;
 	}
@@ -622,7 +622,7 @@ static apr_byte_t oidc_metadata_jwks_retrieve_and_cache(request_rec *r,
 	if (oidc_util_http_get(r, jwks_uri->url, NULL, NULL,
 			NULL, jwks_uri->ssl_validate_server, &response, cfg->http_timeout_long,
 			cfg->outgoing_proxy, oidc_dir_cfg_pass_cookies(r), NULL,
-			NULL) == FALSE)
+			NULL, NULL) == FALSE)
 		return FALSE;
 
 	/* decode and see if it is not an error response somehow */
@@ -693,7 +693,7 @@ apr_byte_t oidc_metadata_provider_retrieve(request_rec *r, oidc_cfg *cfg,
 			cfg->provider.ssl_validate_server, response,
 			cfg->http_timeout_short, cfg->outgoing_proxy,
 			oidc_dir_cfg_pass_cookies(r),
-			NULL, NULL) == FALSE)
+			NULL, NULL, NULL) == FALSE)
 		return FALSE;
 
 	/* decode and see if it is not an error response somehow */

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2627,7 +2627,7 @@ static void oidc_revoke_tokens(request_rec *r, oidc_cfg *c,
 				params, basic_auth, bearer_auth, c->oauth.ssl_validate_server,
 				&response, c->http_timeout_long, c->outgoing_proxy,
 				oidc_dir_cfg_pass_cookies(r), NULL,
-				NULL) == FALSE) {
+				NULL, NULL) == FALSE) {
 			oidc_warn(r, "revoking refresh token failed");
 		}
 		apr_table_clear(params);
@@ -2642,7 +2642,7 @@ static void oidc_revoke_tokens(request_rec *r, oidc_cfg *c,
 				params, basic_auth, bearer_auth, c->oauth.ssl_validate_server,
 				&response, c->http_timeout_long, c->outgoing_proxy,
 				oidc_dir_cfg_pass_cookies(r), NULL,
-				NULL) == FALSE) {
+				NULL, NULL) == FALSE) {
 			oidc_warn(r, "revoking access token failed");
 		}
 	}

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -317,6 +317,7 @@ typedef struct oidc_oauth_t {
 	char *client_secret;
 	char *metadata_url;
 	char *introspection_endpoint_tls_client_key;
+	char *introspection_endpoint_tls_client_key_pwd;
 	char *introspection_endpoint_tls_client_cert;
 	char *introspection_endpoint_url;
 	char *introspection_endpoint_method;

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -266,6 +266,7 @@ typedef struct oidc_provider_t {
 	char *client_id;
 	char *client_secret;
 	char *token_endpoint_tls_client_key;
+	char *token_endpoint_tls_client_key_pwd;
 	char *token_endpoint_tls_client_cert;
 	int backchannel_logout_supported;
 
@@ -745,9 +746,9 @@ char *oidc_normalize_header_name(const request_rec *r, const char *str);
 apr_byte_t oidc_util_request_is_secure(request_rec *r);
 void oidc_util_set_cookie(request_rec *r, const char *cookieName, const char *cookieValue, apr_time_t expires, const char *ext);
 char *oidc_util_get_cookie(request_rec *r, const char *cookieName);
-apr_byte_t oidc_util_http_get(request_rec *r, const char *url, const apr_table_t *params, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key);
-apr_byte_t oidc_util_http_post_form(request_rec *r, const char *url, const apr_table_t *params, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key);
-apr_byte_t oidc_util_http_post_json(request_rec *r, const char *url, json_t *data, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key);
+apr_byte_t oidc_util_http_get(request_rec *r, const char *url, const apr_table_t *params, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key, const char *ssl_key_pwd);
+apr_byte_t oidc_util_http_post_form(request_rec *r, const char *url, const apr_table_t *params, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key, const char *ssl_key_pwd);
+apr_byte_t oidc_util_http_post_json(request_rec *r, const char *url, json_t *data, const char *basic_auth, const char *bearer_token, int ssl_validate_server, char **response, int timeout, const char *outgoing_proxy, apr_array_header_t *pass_cookies, const char *ssl_cert, const char *ssl_key, const char *ssl_key_pwd);
 apr_byte_t oidc_util_request_matches_url(request_rec *r, const char *url);
 apr_byte_t oidc_util_request_has_parameter(request_rec *r, const char* param);
 apr_byte_t oidc_util_get_request_parameter(request_rec *r, char *name, char **value);

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -59,7 +59,7 @@ apr_byte_t oidc_oauth_metadata_provider_retrieve(request_rec *r, oidc_cfg *cfg,
 	if (oidc_util_http_get(r, url, NULL, NULL, NULL,
 			cfg->oauth.ssl_validate_server, response, cfg->http_timeout_short,
 			cfg->outgoing_proxy, oidc_dir_cfg_pass_cookies(r),
-			NULL, NULL) == FALSE)
+			NULL, NULL, NULL) == FALSE)
 		return FALSE;
 
 	/* decode and see if it is not an error response somehow */
@@ -174,17 +174,23 @@ static apr_byte_t oidc_oauth_validate_access_token(request_rec *r, oidc_cfg *c,
 							oidc_dir_cfg_pass_cookies(r),
 							oidc_util_get_full_path(r->pool,
 									c->oauth.introspection_endpoint_tls_client_cert),
-									oidc_util_get_full_path(r->pool,
-											c->oauth.introspection_endpoint_tls_client_key)) :
-											oidc_util_http_post_form(r, c->oauth.introspection_endpoint_url,
-													params, basic_auth, bearer_auth,
-													c->oauth.ssl_validate_server, response,
-													c->http_timeout_long, c->outgoing_proxy,
-													oidc_dir_cfg_pass_cookies(r),
-													oidc_util_get_full_path(r->pool,
-															c->oauth.introspection_endpoint_tls_client_cert),
-															oidc_util_get_full_path(r->pool,
-																	c->oauth.introspection_endpoint_tls_client_key));
+							oidc_util_get_full_path(r->pool,
+									c->oauth.introspection_endpoint_tls_client_key),
+							oidc_util_get_full_path(r->pool,
+									c->oauth.introspection_endpoint_tls_client_key_pwd)
+					) :
+					oidc_util_http_post_form(r, c->oauth.introspection_endpoint_url,
+							params, basic_auth, bearer_auth,
+							c->oauth.ssl_validate_server, response,
+							c->http_timeout_long, c->outgoing_proxy,
+							oidc_dir_cfg_pass_cookies(r),
+							oidc_util_get_full_path(r->pool,
+									c->oauth.introspection_endpoint_tls_client_cert),
+							oidc_util_get_full_path(r->pool,
+									c->oauth.introspection_endpoint_tls_client_key),
+							oidc_util_get_full_path(r->pool,
+									c->oauth.introspection_endpoint_tls_client_key_pwd)
+					);
 }
 
 /*

--- a/src/proto.c
+++ b/src/proto.c
@@ -2240,7 +2240,7 @@ static apr_byte_t oidc_proto_resolve_composite_claims(request_rec *r,
 							NULL, NULL, access_token, cfg->provider.ssl_validate_server,
 							&s_json, cfg->http_timeout_long,
 							cfg->outgoing_proxy, oidc_dir_cfg_pass_cookies(r),
-							NULL, NULL);
+							NULL, NULL, NULL);
 				}
 			}
 			if ((s_json != NULL) && (strcmp(s_json, "") != 0)) {
@@ -2305,7 +2305,7 @@ apr_byte_t oidc_proto_resolve_userinfo(request_rec *r, oidc_cfg *cfg,
 		if (oidc_util_http_get(r, provider->userinfo_endpoint_url,
 				NULL, NULL, access_token, provider->ssl_validate_server, response,
 				cfg->http_timeout_long, cfg->outgoing_proxy,
-				oidc_dir_cfg_pass_cookies(r), NULL, NULL) == FALSE)
+				oidc_dir_cfg_pass_cookies(r), NULL, NULL, NULL) == FALSE)
 			return FALSE;
 	} else if (provider->userinfo_token_method
 			== OIDC_USER_INFO_TOKEN_METHOD_POST) {
@@ -2314,7 +2314,7 @@ apr_byte_t oidc_proto_resolve_userinfo(request_rec *r, oidc_cfg *cfg,
 		if (oidc_util_http_post_form(r, provider->userinfo_endpoint_url, params,
 				NULL, NULL, provider->ssl_validate_server, response,
 				cfg->http_timeout_long, cfg->outgoing_proxy,
-				oidc_dir_cfg_pass_cookies(r), NULL, NULL) == FALSE)
+				oidc_dir_cfg_pass_cookies(r), NULL, NULL, NULL) == FALSE)
 			return FALSE;
 	} else {
 		oidc_error(r, "unsupported userinfo token presentation method: %d",
@@ -2379,7 +2379,7 @@ static apr_byte_t oidc_proto_webfinger_discovery(request_rec *r, oidc_cfg *cfg,
 	if (oidc_util_http_get(r, url, params, NULL, NULL,
 			cfg->provider.ssl_validate_server, &response,
 			cfg->http_timeout_short, cfg->outgoing_proxy,
-			oidc_dir_cfg_pass_cookies(r), NULL, NULL) == FALSE) {
+			oidc_dir_cfg_pass_cookies(r), NULL, NULL, NULL) == FALSE) {
 		/* errors will have been logged by now */
 		return FALSE;
 	}

--- a/src/proto.c
+++ b/src/proto.c
@@ -1996,8 +1996,11 @@ static apr_byte_t oidc_proto_token_endpoint_request(request_rec *r,
 			oidc_dir_cfg_pass_cookies(r),
 			oidc_util_get_full_path(r->pool,
 					provider->token_endpoint_tls_client_cert),
-					oidc_util_get_full_path(r->pool,
-							provider->token_endpoint_tls_client_key)) == FALSE) {
+			oidc_util_get_full_path(r->pool,
+					provider->token_endpoint_tls_client_key),
+			oidc_util_get_full_path(r->pool,
+					provider->token_endpoint_tls_client_key_pwd)
+			) == FALSE) {
 		oidc_warn(r, "error when calling the token endpoint (%s)",
 				provider->token_endpoint_url);
 		return FALSE;

--- a/src/util.c
+++ b/src/util.c
@@ -1628,10 +1628,9 @@ apr_byte_t oidc_util_read_post_params(request_rec *r, apr_table_t *table,
 	const char *content_type = NULL;
 
 	content_type = oidc_util_hdr_in_content_type_get(r);
-	if ((r->method_number != M_POST) || (strstr(content_type,
+	if ((r->method_number != M_POST) || (content_type == NULL) || (strstr(content_type,
 			OIDC_CONTENT_TYPE_FORM_ENCODED) != content_type)) {
-		oidc_debug(r, "required content-type %s not found",
-				OIDC_CONTENT_TYPE_FORM_ENCODED);
+		oidc_debug(r, "required content-type %s not found", OIDC_CONTENT_TYPE_FORM_ENCODED);
 		goto end;
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -679,7 +679,7 @@ static apr_byte_t oidc_util_http_call(request_rec *r, const char *url,
 
 	/* do some logging about the inputs */
 	oidc_debug(r,
-			"url=%s, data=%s, content_type=%s, basic_auth=%s, bearer_token=%s, ssl_validate_server=%d, timeout=%d, outgoing_proxy=%s, pass_cookies=%pp, ssl_cert=%s, ssl_key=%s",
+			"url=%s, data=%s, content_type=%s, basic_auth=%s, bearer_token=%s, ssl_validate_server=%d, timeout=%d, outgoing_proxy=%s, pass_cookies=%pp, ssl_cert=%s, ssl_key=%s, ssl_key_pwd=%s",
 			url, data, content_type, basic_auth ? "****" : "null", bearer_token,
 					ssl_validate_server, timeout, outgoing_proxy, pass_cookies,
 					ssl_cert, ssl_key, ssl_key_pwd ? "****" : "null");
@@ -815,9 +815,8 @@ static apr_byte_t oidc_util_http_call(request_rec *r, const char *url,
 		curl_easy_setopt(curl, CURLOPT_SSLCERT, ssl_cert);
 	if (ssl_key != NULL)
 		curl_easy_setopt(curl, CURLOPT_SSLKEY, ssl_key);
-
 	if (ssl_key_pwd != NULL)
-		curl_easy_setopt(curl, CURLOPT_KEYPASSWD, ssl_key_pwd)
+		curl_easy_setopt(curl, CURLOPT_KEYPASSWD, ssl_key_pwd);
 
 	if (data != NULL) {
 		/* set POST data */

--- a/src/util.c
+++ b/src/util.c
@@ -668,7 +668,7 @@ static apr_byte_t oidc_util_http_call(request_rec *r, const char *url,
 		const char *bearer_token, int ssl_validate_server, char **response,
 		int timeout, const char *outgoing_proxy,
 		apr_array_header_t *pass_cookies, const char *ssl_cert,
-		const char *ssl_key) {
+		const char *ssl_key, const char *ssl_key_pwd) {
 	char curlError[CURL_ERROR_SIZE];
 	oidc_curl_buffer curlBuffer;
 	CURL *curl;
@@ -682,7 +682,7 @@ static apr_byte_t oidc_util_http_call(request_rec *r, const char *url,
 			"url=%s, data=%s, content_type=%s, basic_auth=%s, bearer_token=%s, ssl_validate_server=%d, timeout=%d, outgoing_proxy=%s, pass_cookies=%pp, ssl_cert=%s, ssl_key=%s",
 			url, data, content_type, basic_auth ? "****" : "null", bearer_token,
 					ssl_validate_server, timeout, outgoing_proxy, pass_cookies,
-					ssl_cert, ssl_key);
+					ssl_cert, ssl_key, ssl_key_pwd ? "****" : "null");
 
 	curl = curl_easy_init();
 	if (curl == NULL) {
@@ -816,6 +816,9 @@ static apr_byte_t oidc_util_http_call(request_rec *r, const char *url,
 	if (ssl_key != NULL)
 		curl_easy_setopt(curl, CURLOPT_SSLKEY, ssl_key);
 
+	if (ssl_key_pwd != NULL)
+		curl_easy_setopt(curl, CURLOPT_KEYPASSWD, ssl_key_pwd)
+
 	if (data != NULL) {
 		/* set POST data */
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
@@ -898,11 +901,11 @@ apr_byte_t oidc_util_http_get(request_rec *r, const char *url,
 		const char *bearer_token, int ssl_validate_server, char **response,
 		int timeout, const char *outgoing_proxy,
 		apr_array_header_t *pass_cookies, const char *ssl_cert,
-		const char *ssl_key) {
+		const char *ssl_key, const char *ssl_key_pwd) {
 	char *query_url = oidc_util_http_query_encoded_url(r, url, params);
 	return oidc_util_http_call(r, query_url, NULL, NULL, basic_auth,
 			bearer_token, ssl_validate_server, response, timeout,
-			outgoing_proxy, pass_cookies, ssl_cert, ssl_key);
+			outgoing_proxy, pass_cookies, ssl_cert, ssl_key, ssl_key_pwd);
 }
 
 /*
@@ -913,12 +916,12 @@ apr_byte_t oidc_util_http_post_form(request_rec *r, const char *url,
 		const char *bearer_token, int ssl_validate_server, char **response,
 		int timeout, const char *outgoing_proxy,
 		apr_array_header_t *pass_cookies, const char *ssl_cert,
-		const char *ssl_key) {
+		const char *ssl_key, const char *ssl_key_pwd) {
 	char *data = oidc_util_http_form_encoded_data(r, params);
 	return oidc_util_http_call(r, url, data,
 			OIDC_CONTENT_TYPE_FORM_ENCODED, basic_auth, bearer_token,
 			ssl_validate_server, response, timeout, outgoing_proxy,
-			pass_cookies, ssl_cert, ssl_key);
+			pass_cookies, ssl_cert, ssl_key, ssl_key_pwd);
 }
 
 /*
@@ -928,13 +931,13 @@ apr_byte_t oidc_util_http_post_json(request_rec *r, const char *url,
 		json_t *json, const char *basic_auth, const char *bearer_token,
 		int ssl_validate_server, char **response, int timeout,
 		const char *outgoing_proxy, apr_array_header_t *pass_cookies,
-		const char *ssl_cert, const char *ssl_key) {
+		const char *ssl_cert, const char *ssl_key, const char *ssl_key_pwd) {
 	char *data =
 			json != NULL ?
 					oidc_util_encode_json_object(r, json, JSON_COMPACT) : NULL;
 	return oidc_util_http_call(r, url, data, OIDC_CONTENT_TYPE_JSON, basic_auth,
 			bearer_token, ssl_validate_server, response, timeout,
-			outgoing_proxy, pass_cookies, ssl_cert, ssl_key);
+			outgoing_proxy, pass_cookies, ssl_cert, ssl_key, ssl_key_pwd);
 }
 
 /*


### PR DESCRIPTION
I think I got everything!

1. Sample config updated with new OIDCClientTokenEndpointKeyPasword
2. Config extraction updated with new option.
3. Method parameters updated for all three retrieval types.
4. Method use arguments updated with either the proper provider attribute or NULL in line with the other options.

Still need to test locally to see if this works. C appears to be really annoying to get your local environment set up for.